### PR TITLE
Fix 'chr' function and tpy compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ TESTS_PY_FILES=$(wildcard tests/*.py)
 
 all: tpy tpvm
 
+# alias
+lib: libtpy.so
+
 modules/modules.c: $(MAKEFILE)
 	echo "#include <tinypy/tp.h>" > $@
 	for name in $(MODULES); do echo "void $${name}_init(TP);" >> $@; done
@@ -52,6 +55,11 @@ tpvm-dbg : $(VMLIB_FILES:%.c=tinypy/%.o) tinypy/vmmain.c modules/modules.a
 tpy : $(TPLIB_FILES:%.c=tinypy/%.o) tinypy/tpmain.c modules/modules.a
 	$(CC) -o $@ $^ -lm
 
+libtpy.so : CFLAGS += -fPIC
+libtpy.so : $(TPLIB_FILES:%.c=tinypy/%.o)
+	$(CC) -shared $(CFLAGS) -lm -Wl,-soname,$(@) -o $@ $^
+	#ln -s $@.1 $@
+
 test: $(TESTS_PY_FILES) tpy tpvm tpvm-dbg run-tests.sh
 	bash run-tests.sh $(TESTS_PY_FILES)
 
@@ -62,7 +70,7 @@ test-dbg: $(TESTS_PY_FILES) tpy tpvm tpvm-dbg run-tests.sh
 	bash run-tests.sh -dbg $(TESTS_PY_FILES)
 
 clean:
-	rm -rf tpy tpvm tpvm-dbg
+	rm -rf tpy tpvm tpvm-dbg libtpy.so
 	rm -rf $(RUNTIME_C_FILES)
 	rm -rf $(COMPILER_C_FILES)
 	rm -rf tinypy/*.o

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -12,16 +12,24 @@ fi
 
 TESTS=$@
 
+# `TPY=1 make test` to run with tpy
+TPY=${TPY:-0}
+
 function run {
     tpc=${1//.py/.tpc}
     if [[ "${tpc}" == "$1" ]]; then
         echo $1 does not end with .py
         exit 1
     fi
-    echo "./tpc -o ${tpc} $1"
-    echo "${TPVM} ${tpc}"
-    ./tpc -o ${tpc} $1 || return 1
-    "${TPVM}" ${tpc} || return 1
+    if [[ "${TPY}" == "0" ]]; then
+        echo "./tpc -o ${tpc} $1"
+        echo "${TPVM} ${tpc}"
+        ./tpc -o ${tpc} $1 || return 1
+        "${TPVM}" ${tpc} || return 1
+    else
+        echo "./tpy $1"
+        ./tpy $1 || return 1
+    fi
 }
 
 st=0

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -11,12 +11,18 @@ class MyTest(UnitTest):
             return a, b, c
         assert func(1, 2, 3, 4) == (1, 2, (3, 4))
 
-    def failure_test_default_pos(self):
+    def test_default_pos(self):
         def func(a, b=9, c=9):
             return a, b, c
         assert func(1) == (1, 9, 9)
         assert func(1, 2) == (1, 2, 9)
         assert func(1, 2, 3) == (1, 2, 3)
+
+    # We need to fix this.
+    def known_failure_test_default_pos_mixed(self):
+        def func(a, b=9, c=9):
+            return a, b, c
+        assert func(1, b=9) == (1, 9, 9)
 
     def test_kwargs(self):
         def func(**c):

--- a/tests/test_str.py
+++ b/tests/test_str.py
@@ -54,6 +54,11 @@ class StringUnitTests(UnitTest):
         assert '0123'[None, 1] == '0'
         assert '0123'[None, 2] == '01'
 
+    def test_chr(self):
+        j = chr(0) + chr(65) + chr(66) + chr(0)
+        assert j == '\0AB\0'
+        assert len(j) == 4
+
 if __name__ == '__main__':
     tests = StringUnitTests()
     tests.run()

--- a/tinypy/compiler/encode.py
+++ b/tinypy/compiler/encode.py
@@ -553,7 +553,7 @@ def do_class(t):
     free_reg(kls)
     # As class block is run immediately (unlike function), we shall not create tags or
     # end the frame.
-    D.end(eof=False)
+    D.end(False)    # eof = False
 
 
 def do_while(t):

--- a/tinypy/compiler/tokenize.py
+++ b/tinypy/compiler/tokenize.py
@@ -10,6 +10,10 @@ class Token:
     def __repr__(self):
         return self._format()
 
+    def update(self, other):
+        for k in other:
+            self[k] = other[k]
+
 def u_error(ctx,s,i):
     y,x = i
     line = s.split('\n')[y-1]

--- a/tinypy/tp.h
+++ b/tinypy/tp.h
@@ -247,7 +247,8 @@ typedef struct tp_vm {
     tpd_list *black;
     int steps;
     /* cached objects */
-    char chars[256][2];
+    tp_obj _chars;
+    tp_obj chars[256];
     /* sandbox */
     clock_t clocks;
     double time_elapsed;

--- a/tinypy/tp_ops.c
+++ b/tinypy/tp_ops.c
@@ -192,7 +192,7 @@ _tp_get(TP, tp_obj self, tp_obj k, int mget)
             int n = k.number.val;
             n = (n<0?l+n:n);
             if (n >= 0 && n < l) {
-                return tp_string_atom(tp, tp->chars[(unsigned char) tp_string_getptr(self)[n]]);
+                return tp->chars[(unsigned char) tp_string_getptr(self)[n]];
             }
         } else if (k.type.typeid == TP_STRING) {
             if (_tp_lookup(tp, self, k, &r)) { return r;}

--- a/tinypy/tp_vm.c
+++ b/tinypy/tp_vm.c
@@ -20,11 +20,16 @@ tp_vm * tp_create_vm(void) {
     tp->cur = 0;
     tp->jmp = 0;
 
-    for (i=0; i<256; i++) { tp->chars[i][0]=i; tp->chars[i][1] = 0; }
-
     tp_gc_init(tp);
 
     /* gc initialized, can use tpy_ functions. */
+
+    tp->_chars = tp_list_t(tp);
+    for (i=0; i<256; i++) {
+        tp->chars[i] = tp_string_t(tp, 1);
+        *tp_string_getptr(tp->chars[i]) = i;
+        tp_set(tp, tp->_chars, tp_None, tp->chars[i]);
+    }
 
     tp->_regs = tp_list_t(tp);
     for (i=0; i < TP_REGS + 3; i++) { tp_set(tp, tp->_regs, tp_None, tp_None); }
@@ -50,6 +55,7 @@ tp_vm * tp_create_vm(void) {
     for (i=0; i<TP_FRAMES; i++) { tp_set(tp, tp->_params, tp_None, tp_list_t(tp)); }
     tp->echo = tp_default_echo;
 
+    tp_gc_set_reachable(tp, tp->_chars);
     tp_gc_set_reachable(tp, tp->builtins);
     tp_gc_set_reachable(tp, tp->modules);
     tp_gc_set_reachable(tp, tp->object_class);

--- a/tinypy/tpy_string.c
+++ b/tinypy/tpy_string.c
@@ -1,5 +1,4 @@
 
-/* FIXME: use StringBuilder. */
 tp_obj tpy_str_join(TP) {
     tp_obj delim = TP_OBJ();
     tp_obj val = TP_OBJ();
@@ -60,8 +59,9 @@ tp_obj tpy_str_index(TP) {
 
 tp_obj tpy_chr(TP) {
     int v = TP_NUM();
-    return tp_string_atom(tp, tp->chars[(unsigned char)v]);
+    return tp->chars[(unsigned char)v];
 }
+
 tp_obj tpy_ord(TP) {
     tp_obj s = TP_STR();
     if (tp_string_len(s) != 1) {


### PR DESCRIPTION
In a quest to make a shared library and embed tinypy, I found some errors on tpy compilation and string management.

With these changes, tpy should work (only did a quick test).

The 'chr' function now creates a "true" string object, which allows for the '\0' string/chr. The implementation could be better tho.

Also added to the makefile an option to make a shared library.