### PR TITLE
Rework tpd_frame's memory model.

### DIFF
--- a/modules/re/init.c
+++ b/modules/re/init.c
@@ -345,10 +345,10 @@ static tp_obj match_obj_group(TP)
 	 * if no group index provided, supply default group index 0; else
 	 * fill in indices[] with provided group index list.
 	 */
-	if (tp->params.list.val->len == 0) {
+	if (tp->params->list.val->len == 0) {
 		indices[0] = 0;
 		single = 1;
-	} else if (tp->params.list.val->len == 1) {
+	} else if (tp->params->list.val->len == 1) {
 		indices[0] = (int)TP_NUM();
 		single = 1;
 	} else {

--- a/tinypy/compiler/encode.py
+++ b/tinypy/compiler/encode.py
@@ -473,7 +473,7 @@ def do_def(tok):
 
     D.begin()
     setpos(tok.pos)
-    r = do_local(Token(tok.pos,'name','__params__'))
+    r = do_local(Token(tok.pos,'name','__params__'))  # assigns regs[0] to __params__.
     do_info(items[0].val)
     a,b,c,d = p_filter(items[1].items)
     for p in a:

--- a/tinypy/tp.c
+++ b/tinypy/tp.c
@@ -16,9 +16,9 @@ tp_obj tp_None = {TP_NONE};
 #include "tp_string.c"
 
 #include "tp_meta.c"
-#include "tp_frame.c"
 #include "tp_data.c"
 #include "tp_func.c"
+#include "tp_frame.c"
 
 #include "tp_repr.c"
 

--- a/tinypy/tp.h
+++ b/tinypy/tp.h
@@ -193,6 +193,7 @@ typedef struct tpd_frame {
     tp_obj name;
     tp_obj line;
     tp_obj globals;
+    tp_obj args;
     int lineno;
     int cregs;
     int nregs;

--- a/tinypy/tp.h
+++ b/tinypy/tp.h
@@ -200,8 +200,7 @@ typedef struct tpd_frame {
 
 #define TP_FRAMES 256
 #define TP_REGS_START 5
-/* #define TP_REGS_PER_FRAME 256*/
-#define TP_REGS 16384
+#define TP_REGS_PER_FRAME 256
 
 /* Type: tp_vm
  * Representation of a tinypy virtual machine instance.

--- a/tinypy/tp.h
+++ b/tinypy/tp.h
@@ -199,8 +199,6 @@ typedef struct tpd_frame {
 } tpd_frame;
 
 #define TP_FRAMES 256
-#define TP_REGS_START 5
-#define TP_REGS_PER_FRAME 256
 #define TP_STACK_MAX 4096
 
 /* Type: tp_vm

--- a/tinypy/tp.h
+++ b/tinypy/tp.h
@@ -238,7 +238,6 @@ typedef struct tp_vm {
     tp_obj _params;
     tp_obj params;
     tp_obj _regs;
-    tp_obj *regs;
     tp_obj *last_result;
 
     /* exception */

--- a/tinypy/tp.h
+++ b/tinypy/tp.h
@@ -187,7 +187,7 @@ typedef struct tpd_frame {
     tp_obj code;
     tpd_code *cur;
     tpd_code *jmp;
-    tp_obj *regs;
+    tp_obj *regs;  /* regs is allocated after an IREG byte-code.*/
     tp_obj *ret_dest;
     tp_obj fname;
     tp_obj name;
@@ -196,12 +196,12 @@ typedef struct tpd_frame {
     tp_obj args;
     int lineno;
     int cregs;
-    int nregs;
 } tpd_frame;
 
 #define TP_FRAMES 256
 #define TP_REGS_START 5
 #define TP_REGS_PER_FRAME 256
+#define TP_STACK_MAX 4096
 
 /* Type: tp_vm
  * Representation of a tinypy virtual machine instance.
@@ -232,12 +232,14 @@ typedef struct tp_vm {
     tp_obj dict_class;
     tp_obj string_class;
 
+    /* stack */
+    tpd_list * stack;
+
     /* call */
     int cur;
     tp_obj frames[TP_FRAMES];
     tp_obj _params;
     tp_obj params;
-    tp_obj _regs;
     tp_obj *last_result;
 
     /* exception */
@@ -246,7 +248,6 @@ typedef struct tp_vm {
     jmp_buf nextexpr;
 #endif
     int jmp;
-    tp_obj _exc;
     tp_obj * exc;
     tp_obj * exc_stack;
 

--- a/tinypy/tp.h
+++ b/tinypy/tp.h
@@ -216,8 +216,7 @@ typedef struct tpd_frame {
  * builtins - A dictionary containing all builtin objects.
  * modules - A dictionary with all loaded modules.
  * params - A list of parameters for the current function call.
- * frames - A list of all call frames.
- * cur - The index of the currently executing call frame.
+ * frames - A list of all call frames. list frame is the current frame.
  * frames[n].globals - A dictionary of global sybmols in callframe n.
  */
 typedef struct tp_vm {
@@ -234,8 +233,7 @@ typedef struct tp_vm {
     tpd_list * stack;
 
     /* call */
-    int cur;
-    tp_obj frames[TP_FRAMES];
+    tpd_list * frames;
     tp_obj _params;
     tp_obj params;
     tp_obj *last_result;

--- a/tinypy/tp.h
+++ b/tinypy/tp.h
@@ -189,9 +189,9 @@ typedef struct tpd_frame {
     tpd_code *jmp;
     tp_obj *regs;
     tp_obj *ret_dest;
-    tp_obj *fname;
-    tp_obj *name;
-    tp_obj *line;
+    tp_obj fname;
+    tp_obj name;
+    tp_obj line;
     tp_obj globals;
     int lineno;
     int cregs;

--- a/tinypy/tp.h
+++ b/tinypy/tp.h
@@ -195,10 +195,11 @@ typedef struct tpd_frame {
     tp_obj globals;
     int lineno;
     int cregs;
+    int nregs;
 } tpd_frame;
 
 #define TP_FRAMES 256
-#define TP_REGS_EXTRA 5
+#define TP_REGS_START 5
 /* #define TP_REGS_PER_FRAME 256*/
 #define TP_REGS 16384
 

--- a/tinypy/tp.h
+++ b/tinypy/tp.h
@@ -234,8 +234,7 @@ typedef struct tp_vm {
 
     /* call */
     tpd_list * frames;
-    tp_obj _params;
-    tp_obj params;
+    tp_obj * params;
     tp_obj *last_result;
 
     /* exception */
@@ -255,7 +254,6 @@ typedef struct tp_vm {
     tpd_list *black;
     int steps;
     /* cached objects */
-    tp_obj _chars;
     tp_obj chars[256];
     /* sandbox */
     clock_t clocks;
@@ -358,11 +356,11 @@ tp_obj tp_check_type(TP, int t, tp_obj v) {
  * function scope.
  * */
 #define TP_NO_LIMIT 0
-#define TP_OBJ() (tp_get(tp, tp->params, tp_None))
+#define TP_OBJ() (tp_get(tp, *tp->params, tp_None))
 #define TP_TYPE(t) tp_check_type(tp, t, TP_OBJ())
 #define TP_NUM() (TP_TYPE(TP_NUMBER).number.val)
 #define TP_STR() (TP_TYPE(TP_STRING))
-#define TP_DEFAULT(d) (tp->params.list.val->len?tp_get(tp, tp->params, tp_None):(d))
+#define TP_DEFAULT(d) (tp->params->list.val->len?tp_get(tp, *tp->params, tp_None):(d))
 
 /* Macro: TP_LOOP
  * Macro to iterate over all remaining arguments.
@@ -383,9 +381,9 @@ tp_obj tp_check_type(TP, int t, tp_obj v) {
  */
 tp_obj tpd_list_get(TP, tpd_list *self, int k, const char *error);
 #define TP_LOOP(e) \
-    int __l = tp->params.list.val->len; \
+    int __l = tp->params->list.val->len; \
     int __i; for (__i=0; __i<__l; __i++) { \
-        (e) = tpd_list_get(tp, tp->params.list.val, __i, "TP_LOOP");
+        (e) = tpd_list_get(tp, tp->params->list.val, __i, "TP_LOOP");
 #define TP_END \
     }
 

--- a/tinypy/tp.h
+++ b/tinypy/tp.h
@@ -53,6 +53,7 @@ enum TP_PACKED TPTypeID {
     TP_GC_TRACKED = 9,
     TP_FUNC = 10,
     TP_DATA = 11,
+    TP_FRAME = 12,
 
     TP_STRING = 100,
     TP_DICT = 101,
@@ -121,6 +122,7 @@ typedef union tp_obj {
     struct { TPTypeInfo type; tp_num val; } number;
     struct { TPTypeInfo type; struct tpd_func *info; void *cfnc; } func;
     struct { TPTypeInfo type; struct tpd_data *info; void *val; } data;
+    struct { TPTypeInfo type; struct tpd_frame *info; } frame;
 
     struct { TPTypeInfo type; struct tpd_obj *info; } obj;
     struct { TPTypeInfo type; struct tpd_list *val; } list;
@@ -181,6 +183,7 @@ typedef union tpd_code {
 
 typedef struct tpd_frame {
 /*    tpd_code *codes; */
+    TPGCMask gci;
     tp_obj code;
     tpd_code *cur;
     tpd_code *jmp;
@@ -230,7 +233,7 @@ typedef struct tp_vm {
 
     /* call */
     int cur;
-    tpd_frame frames[TP_FRAMES];
+    tp_obj frames[TP_FRAMES];
     tp_obj _params;
     tp_obj params;
     tp_obj _regs;

--- a/tinypy/tp_frame.c
+++ b/tinypy/tp_frame.c
@@ -2,8 +2,7 @@ tp_obj tp_frame_t(TP) {
     tp_obj r = {TP_FRAME};
     r.frame.info = tp_malloc(tp, sizeof(tpd_frame));
     tpd_frame * f = r.frame.info;
-    /* FIXME: number of regs per frame, make this a parameter. */
-    f->nregs = 256;
+    f->nregs = TP_REGS_PER_FRAME;
     f->regs = tp_malloc(tp, sizeof(tp_obj) * f->nregs);
 
     return r;

--- a/tinypy/tp_frame.c
+++ b/tinypy/tp_frame.c
@@ -1,13 +1,8 @@
-tp_obj tp_frame_t(TP) {
+tp_obj tp_frame_t(TP, tp_obj params, tp_obj globals, tp_obj code, tp_obj * ret_dest) {
     tp_obj r = {TP_FRAME};
     r.frame.info = tp_malloc(tp, sizeof(tpd_frame));
     tpd_frame * f = r.frame.info;
 
-    return r;
-}
-
-void tpd_frame_reset(TP, tpd_frame * f, tp_obj params, tp_obj globals, tp_obj code, tp_obj * ret_dest)
-{
     f->globals = globals;
     f->code = code;
     f->cur = (tpd_code*) tp_string_getptr(f->code);
@@ -19,6 +14,7 @@ void tpd_frame_reset(TP, tpd_frame * f, tp_obj params, tp_obj globals, tp_obj co
     f->name = tp_string_atom(tp, "?");
     f->fname = tp_string_atom(tp, "?");
     f->cregs = 0;
+    return tp_track(tp, r);
 }
 
 void tpd_frame_alloc(TP, tpd_frame * f, tp_obj * regs, int cregs) {

--- a/tinypy/tp_frame.c
+++ b/tinypy/tp_frame.c
@@ -1,30 +1,36 @@
-/* tp_frame_*/
-tpd_frame tp_frame_nt(TP, tp_obj globals, tp_obj code, tp_obj * ret_dest)
+tp_obj tp_frame_t(TP) {
+    tp_obj r = {TP_FRAME};
+    r.frame.info = tp_malloc(tp, sizeof(tpd_frame));
+    return r;
+}
+
+void tpd_frame_reset(TP, tpd_frame * f, tp_obj params, tp_obj globals, tp_obj code, tp_obj * ret_dest)
 {
-    tpd_frame f;
-    f.globals = globals;
-    f.code = code;
-    f.cur = (tpd_code*) tp_string_getptr(f.code);
-    f.jmp = 0;
+    tpd_frame * bf = tp->frames[tp->cur].frame.info;
+    f->globals = globals;
+    f->code = code;
+    f->cur = (tpd_code*) tp_string_getptr(f->code);
+    f->jmp = 0;
 /*     fprintf(stderr,"tp->cur: %d\n",tp->cur);*/
-    f.regs = (tp->cur <= 0?tp->regs:tp->frames[tp->cur].regs+tp->frames[tp->cur].cregs);
+    f->regs = (tp->cur <= 0?tp->regs:bf->regs+bf->cregs);
 
-    f.regs[0] = f.globals;
-    f.regs[1] = f.code;
-    f.line = &f.regs[2];
-    f.name = &f.regs[3];
-    f.fname = &f.regs[4];
-    f.regs += TP_REGS_EXTRA;
+    f->regs[0] = f->globals;
+    f->regs[1] = f->code;
+    f->line = &f->regs[2];
+    f->name = &f->regs[3];
+    f->fname = &f->regs[4];
+    f->regs += TP_REGS_EXTRA;
 
-    if (f.regs+(256+TP_REGS_EXTRA) >= tp->regs+TP_REGS || tp->cur >= TP_FRAMES-1) {
-        tp_raise(f,tp_string_atom(tp, "(tp_frame) RuntimeError: stack overflow"));
+    if (f->regs+(256+TP_REGS_EXTRA) >= tp->regs+TP_REGS || tp->cur >= TP_FRAMES-1) {
+        tp_raise(, tp_string_atom(tp, "(tp_frame) RuntimeError: stack overflow"));
     }
 
-    f.ret_dest = ret_dest;
-    f.lineno = 0;
-    *f.line = tp_string_atom(tp, "");
-    *f.name = tp_string_atom(tp, "?");
-    *f.fname = tp_string_atom(tp, "?");
-    f.cregs = 0;
-    return f;
+    f->ret_dest = ret_dest;
+    f->lineno = 0;
+    *f->line = tp_string_atom(tp, "");
+    *f->name = tp_string_atom(tp, "?");
+    *f->fname = tp_string_atom(tp, "?");
+    f->cregs = 0;
+    /* calling convention AX = params. who picks this up? */
+    f->regs[0] = params;
 }

--- a/tinypy/tp_frame.c
+++ b/tinypy/tp_frame.c
@@ -1,6 +1,11 @@
 tp_obj tp_frame_t(TP) {
     tp_obj r = {TP_FRAME};
     r.frame.info = tp_malloc(tp, sizeof(tpd_frame));
+    tpd_frame * f = r.frame.info;
+    /* FIXME: number of regs per frame, make this a parameter. */
+    f->nregs = 256;
+    f->regs = tp_malloc(tp, sizeof(tp_obj) * f->nregs);
+
     return r;
 }
 
@@ -11,23 +16,14 @@ void tpd_frame_reset(TP, tpd_frame * f, tp_obj params, tp_obj globals, tp_obj co
     f->code = code;
     f->cur = (tpd_code*) tp_string_getptr(f->code);
     f->jmp = 0;
-/*     fprintf(stderr,"tp->cur: %d\n",tp->cur);*/
-    f->regs = (tp->cur <= 0?tp->regs:bf->regs+bf->cregs);
-
     f->regs[0] = f->globals;
     f->regs[1] = f->code;
-    f->regs += TP_REGS_EXTRA;
-
-    if (f->regs+(256+TP_REGS_EXTRA) >= tp->regs+TP_REGS || tp->cur >= TP_FRAMES-1) {
-        tp_raise(, tp_string_atom(tp, "(tp_frame) RuntimeError: stack overflow"));
-    }
-
     f->ret_dest = ret_dest;
     f->lineno = 0;
     f->line = tp_string_atom(tp, "");
     f->name = tp_string_atom(tp, "?");
     f->fname = tp_string_atom(tp, "?");
-    f->cregs = 0;
+    f->cregs = TP_REGS_START + 1;
     /* calling convention AX = params. who picks this up? */
-    f->regs[0] = params;
+    f->regs[TP_REGS_START] = params;
 }

--- a/tinypy/tp_frame.c
+++ b/tinypy/tp_frame.c
@@ -16,9 +16,6 @@ void tpd_frame_reset(TP, tpd_frame * f, tp_obj params, tp_obj globals, tp_obj co
 
     f->regs[0] = f->globals;
     f->regs[1] = f->code;
-    f->line = &f->regs[2];
-    f->name = &f->regs[3];
-    f->fname = &f->regs[4];
     f->regs += TP_REGS_EXTRA;
 
     if (f->regs+(256+TP_REGS_EXTRA) >= tp->regs+TP_REGS || tp->cur >= TP_FRAMES-1) {
@@ -27,9 +24,9 @@ void tpd_frame_reset(TP, tpd_frame * f, tp_obj params, tp_obj globals, tp_obj co
 
     f->ret_dest = ret_dest;
     f->lineno = 0;
-    *f->line = tp_string_atom(tp, "");
-    *f->name = tp_string_atom(tp, "?");
-    *f->fname = tp_string_atom(tp, "?");
+    f->line = tp_string_atom(tp, "");
+    f->name = tp_string_atom(tp, "?");
+    f->fname = tp_string_atom(tp, "?");
     f->cregs = 0;
     /* calling convention AX = params. who picks this up? */
     f->regs[0] = params;

--- a/tinypy/tp_frame.c
+++ b/tinypy/tp_frame.c
@@ -2,8 +2,6 @@ tp_obj tp_frame_t(TP) {
     tp_obj r = {TP_FRAME};
     r.frame.info = tp_malloc(tp, sizeof(tpd_frame));
     tpd_frame * f = r.frame.info;
-    f->nregs = TP_REGS_PER_FRAME;
-    f->regs = tp_malloc(tp, sizeof(tp_obj) * f->nregs);
 
     return r;
 }
@@ -14,26 +12,22 @@ void tpd_frame_reset(TP, tpd_frame * f, tp_obj params, tp_obj globals, tp_obj co
     f->code = code;
     f->cur = (tpd_code*) tp_string_getptr(f->code);
     f->jmp = 0;
-    f->regs[0] = f->globals;
-    f->regs[1] = f->code;
     f->ret_dest = ret_dest;
     f->lineno = 0;
     f->args = params;
     f->line = tp_string_atom(tp, "");
     f->name = tp_string_atom(tp, "?");
     f->fname = tp_string_atom(tp, "?");
-    f->cregs = TP_REGS_START;
+    f->cregs = 0;
 }
 
-void tpd_frame_alloc(TP, tpd_frame * f, int cregs) {
+void tpd_frame_alloc(TP, tpd_frame * f, tp_obj * regs, int cregs) {
     /*  call convention requires 1 reg for __params__.*/
     if(cregs < 1) {
         abort();
     }
-    /* calling convention AX = params. who picks this up? */
-    f->regs[TP_REGS_START] = f->args;
-    f->cregs = TP_REGS_START + cregs;
-    if (f->cregs > f->nregs) {
-        tp_raise_printf(, "(tp_step) RuntimeError: register overrun, requesting %d registers, frame has %d.", f->cregs, f->nregs);
-    }
+    f->regs = regs;
+    /* calling convention local #0 = params. */
+    f->regs[0] = f->args;
+    f->cregs = cregs;
 }

--- a/tinypy/tp_gc.c
+++ b/tinypy/tp_gc.c
@@ -77,6 +77,9 @@ void tp_follow(TP,tp_obj v) {
         tp_grey(tp,v.func.info->code);
     }
     if (type == TP_FRAME) {
+        tp_grey(tp, v.frame.info->line);
+        tp_grey(tp, v.frame.info->name);
+        tp_grey(tp, v.frame.info->fname);
         tp_grey(tp, v.frame.info->code);
         tp_grey(tp, v.frame.info->globals);
     }

--- a/tinypy/tp_gc.c
+++ b/tinypy/tp_gc.c
@@ -140,6 +140,7 @@ void tp_delete(TP, tp_obj v) {
         return;
     } else if (type == TP_FRAME) {
         tp_free(tp, v.frame.info);
+        return;
     }
     tp_raise(, tp_string_atom(tp, "(tp_delete) TypeError: ?"));
 }

--- a/tinypy/tp_gc.c
+++ b/tinypy/tp_gc.c
@@ -126,6 +126,8 @@ void tp_delete(TP, tp_obj v) {
     } else if (type == TP_FUNC) {
         tp_free(tp, v.func.info);
         return;
+    } else if (type == TP_FRAME) {
+        tp_free(tp, v.frame.info);
     }
     tp_raise(, tp_string_atom(tp, "(tp_delete) TypeError: ?"));
 }

--- a/tinypy/tp_gc.c
+++ b/tinypy/tp_gc.c
@@ -78,7 +78,7 @@ void tp_follow(TP,tp_obj v) {
     }
     if (type == TP_FRAME) {
         int i;
-        for(i = 0; i < v.frame.info->nregs; i ++) {
+        for(i = 0; i < v.frame.info->cregs; i ++) {
             tp_grey(tp, v.frame.info->regs[i]);
         }
         tp_grey(tp, v.frame.info->line);

--- a/tinypy/tp_gc.c
+++ b/tinypy/tp_gc.c
@@ -86,6 +86,7 @@ void tp_follow(TP,tp_obj v) {
         tp_grey(tp, v.frame.info->fname);
         tp_grey(tp, v.frame.info->code);
         tp_grey(tp, v.frame.info->globals);
+        tp_grey(tp, v.frame.info->args);
     }
 }
 

--- a/tinypy/tp_gc.c
+++ b/tinypy/tp_gc.c
@@ -77,6 +77,10 @@ void tp_follow(TP,tp_obj v) {
         tp_grey(tp,v.func.info->code);
     }
     if (type == TP_FRAME) {
+        int i;
+        for(i = 0; i < v.frame.info->nregs; i ++) {
+            tp_grey(tp, v.frame.info->regs[i]);
+        }
         tp_grey(tp, v.frame.info->line);
         tp_grey(tp, v.frame.info->name);
         tp_grey(tp, v.frame.info->fname);

--- a/tinypy/tp_gc.c
+++ b/tinypy/tp_gc.c
@@ -76,6 +76,10 @@ void tp_follow(TP,tp_obj v) {
         tp_grey(tp,v.func.info->globals);
         tp_grey(tp,v.func.info->code);
     }
+    if (type == TP_FRAME) {
+        tp_grey(tp, v.frame.info->code);
+        tp_grey(tp, v.frame.info->globals);
+    }
 }
 
 void tp_gc_init(TP) {

--- a/tinypy/tp_import.c
+++ b/tinypy/tp_import.c
@@ -11,7 +11,7 @@ tp_obj tp_import(TP, tp_obj name, tp_obj code, tp_obj fname) {
 
     /* an older versoin of the code does not run frame of jmp == 0. Why?*/
     /*
-     tp_enter_frame(tp, globals, code, &r);
+     tp_enter_frame(tp, tp_None, globals, code, &r);
      if (!tp->jmp) {
          tp_run_frame(tp);
      } 

--- a/tinypy/tp_internal.h
+++ b/tinypy/tp_internal.h
@@ -21,7 +21,8 @@
 tp_inline static int _tp_min(int a, int b) { return (a<b?a:b); }
 tp_inline static int _tp_max(int a, int b) { return (a>b?a:b); }
 tp_inline static int _tp_sign(tp_num v) { return (v<0?-1:(v>0?1:0)); }
-tp_inline static tpd_frame * tp_get_cur_frame(TP) { return tp->frames[tp->cur].frame.info; }
+tp_inline static tpd_frame * tp_get_frame(TP, int i) { return tp->frames->items[i].frame.info; }
+tp_inline static tpd_frame * tp_get_cur_frame(TP) { return tp_get_frame(tp, tp->frames->len - 1); }
 
 /* Detect unintended size changes. Update as needed. */
 STATIC_ASSERT(sizeof(tpd_code) == 4, "size of tpd_code must be 4");

--- a/tinypy/tp_internal.h
+++ b/tinypy/tp_internal.h
@@ -21,6 +21,7 @@
 tp_inline static int _tp_min(int a, int b) { return (a<b?a:b); }
 tp_inline static int _tp_max(int a, int b) { return (a>b?a:b); }
 tp_inline static int _tp_sign(tp_num v) { return (v<0?-1:(v>0?1:0)); }
+tp_inline static tpd_frame * tp_get_cur_frame(TP) { return tp->frames[tp->cur].frame.info; }
 
 /* Detect unintended size changes. Update as needed. */
 STATIC_ASSERT(sizeof(tpd_code) == 4, "size of tpd_code must be 4");

--- a/tinypy/tp_ops.c
+++ b/tinypy/tp_ops.c
@@ -449,10 +449,9 @@ tp_obj tp_call(TP, tp_obj self, tp_obj params) {
         } else {
             /* compiled Python function */
             tp_obj dest = tp_None;
-            tp_enter_frame(tp, self.func.info->globals,
+            tp_enter_frame(tp, params, self.func.info->globals,
                                self.func.info->code,
                               &dest);
-            tp->frames[tp->cur].regs[0] = params;
             tp_run_frame(tp);
             return dest;
         }

--- a/tinypy/tp_ops.c
+++ b/tinypy/tp_ops.c
@@ -439,7 +439,7 @@ tp_obj tp_call(TP, tp_obj self, tp_obj params) {
         }
         if(self.func.cfnc != NULL) {
             /* C func, set tp->params for the CAPI calling convention. */
-            tp->params = params;
+            *tp->params = params;
 
             tp_obj (* cfunc)(tp_vm *);
             cfunc = self.func.cfnc;

--- a/tinypy/tp_param.c
+++ b/tinypy/tp_param.c
@@ -7,8 +7,8 @@
  */
 tp_obj tp_params(TP) {
     tp_obj r;
-    tp->params = tp->_params.list.val->items[tp->cur];
-    r = tp->_params.list.val->items[tp->cur];
+    tp->params = tp->_params.list.val->items[tp->frames->len];
+    r = tp->_params.list.val->items[tp->frames->len];
     r.list.val->len = 0;
     return r;
 }

--- a/tinypy/tp_param.c
+++ b/tinypy/tp_param.c
@@ -4,13 +4,13 @@
  * When you are calling a tinypy function, you can use this to initialize the
  * list of parameters getting passed to it. Usually, you may want to use
  * <tp_params_n> or <tp_params_v>.
+ *
+ * In a C-API function, always finish 'parsing' the params before calling other
+ * tpy functions or tp_exec (which may eventually call other tpy functions).
  */
 tp_obj tp_params(TP) {
-    tp_obj r;
-    tp->params = tp->_params.list.val->items[tp->frames->len];
-    r = tp->_params.list.val->items[tp->frames->len];
-    r.list.val->len = 0;
-    return r;
+    *tp->params = tp_list_t(tp);
+    return *tp->params;
 }
 
 /* Function: tp_params_n

--- a/tinypy/tp_vm.c
+++ b/tinypy/tp_vm.c
@@ -55,6 +55,7 @@ tp_vm * tp_create_vm(void) {
     tp->stack->len = 0;
     tp_gc_set_reachable(tp, stack);
 
+    tp->params = tp_stack_alloc(tp, 1);
     tp->last_result = tp_stack_alloc(tp, 1);
     tp->exc = tp_stack_alloc(tp, 1);
     tp->exc_stack = tp_stack_alloc(tp, 1);
@@ -70,9 +71,6 @@ tp_vm * tp_create_vm(void) {
     tp->builtins = tp_dict_t(tp);
     tp->modules = tp_dict_t(tp);
 
-    tp->_params = tp_list_t(tp);
-
-    for (i=0; i<TP_FRAMES; i++) { tp_set(tp, tp->_params, tp_None, tp_list_t(tp)); }
     tp->echo = tp_default_echo;
 
     tp_obj frames = tp_list_t(tp);
@@ -86,7 +84,6 @@ tp_vm * tp_create_vm(void) {
     tp_gc_set_reachable(tp, tp->builtins);
     tp_gc_set_reachable(tp, tp->modules);
     tp_gc_set_reachable(tp, tp->object_class);
-    tp_gc_set_reachable(tp, tp->_params);
 
     tp_gc_set_reachable(tp, tp->list_class);
     tp_gc_set_reachable(tp, tp->dict_class);

--- a/tinypy/tp_vm.c
+++ b/tinypy/tp_vm.c
@@ -110,12 +110,12 @@ void tp_format_stack_internal(TP, StringBuilder * sb)
         tpd_frame * f = tp->frames[i].frame.info;
         if (!f->lineno) { continue; }
         string_builder_write(sb, "File \"", -1);
-        string_builder_echo(sb, *f->fname);
+        string_builder_echo(sb, f->fname);
         string_builder_write(sb, "\", ", -1);
         string_builder_echo(sb, tp_printf(tp, "line %d, in ", f->lineno));
-        string_builder_echo(sb, *f->name);
+        string_builder_echo(sb, f->name);
         string_builder_write(sb, "\n ", -1);
-        string_builder_echo(sb, *f->line);
+        string_builder_echo(sb, f->line);
         string_builder_write(sb, "\n", -1);
     }
 }
@@ -327,12 +327,12 @@ int tp_step(TP) {
             ;
             int a = (*(cur+1)).string.val - tp_string_getptr(f->code);
             if(tp_string_getptr(f->code)[a] == ';') abort();
-            *f->line = tp_string_view(tp, f->code, a, a+VA*4-1);
+            f->line = tp_string_view(tp, f->code, a, a+VA*4-1);
             cur += VA; f->lineno = UVBC;
             }
             break;
-        case TP_IFILE: *f->fname = RA; break;
-        case TP_INAME: *f->name = RA; break;
+        case TP_IFILE: f->fname = RA; break;
+        case TP_INAME: f->name = RA; break;
         case TP_IVAR: {
             cur += (UVBC/4) + 1;
             /* Watch out: crash if continue. */

--- a/tinypy/tp_vm.c
+++ b/tinypy/tp_vm.c
@@ -10,6 +10,7 @@ tp_obj * tp_stack_alloc(TP, int n) {
     if(tp->stack->len > TP_STACK_MAX) {
         tp_raise(NULL, tp_string_atom(tp, "(tp_stack_alloc) out of stack space"));
     }
+    memset(r, 0, sizeof(tp_obj) * n);
     return r;
 }
 
@@ -233,7 +234,7 @@ int tp_step(TP) {
     tpd_code e = *cur;
     tpd_code *base = (tpd_code*)f->code.string.info->s;
     /* FIXME: convert this to a flag */
-//     fprintf(stdout,"%2d.%4d: %-6s %3d %3d %3d\n",tp->frames->len - 1, (cur - base) * 4,tp_get_opcode_name(e.i),VA,VB,VC);
+    // fprintf(stdout,"[%04d] %2d.%4d: %-6s %3d %3d %3d\n",tp->steps, tp->frames->len - 1, (cur - base) * 4,tp_get_opcode_name(e.i),VA,VB,VC);
 //       int i; for(i=0;i<16;i++) { fprintf(stderr,"%d: %s\n",i,TP_xSTR(f->regs[i])); }
    
 //    tp_obj tpy_print(TP);

--- a/tinypy/tp_vm.c
+++ b/tinypy/tp_vm.c
@@ -32,7 +32,7 @@ tp_vm * tp_create_vm(void) {
     }
 
     tp->_regs = tp_list_t(tp);
-    for (i=0; i < TP_REGS + 3; i++) { tp_set(tp, tp->_regs, tp_None, tp_None); }
+    for (i=0; i < 3; i++) { tp_set(tp, tp->_regs, tp_None, tp_None); }
 
     tp->last_result = tp->_regs.list.val->items + 0;
     tp->exc = tp->_regs.list.val->items + 1;

--- a/tinypy/tp_vm.c
+++ b/tinypy/tp_vm.c
@@ -37,7 +37,6 @@ tp_vm * tp_create_vm(void) {
     tp->last_result = tp->_regs.list.val->items + 0;
     tp->exc = tp->_regs.list.val->items + 1;
     tp->exc_stack = tp->_regs.list.val->items + 2;
-    tp->regs = tp->_regs.list.val->items + 3;
 
     tp_obj object_class = tp_object(tp);
     object_class.type.magic = TP_DICT_CLASS;

--- a/tinypy/tpy_builtins.c
+++ b/tinypy/tpy_builtins.c
@@ -300,7 +300,7 @@ tp_obj tpy_eval(TP) {
 }
 
 tp_obj tpy_globals(TP) {
-    return tp->frames[tp->cur].globals;
+    return tp->frames[tp->cur].frame.info->globals;
 }
 
 

--- a/tinypy/tpy_builtins.c
+++ b/tinypy/tpy_builtins.c
@@ -46,7 +46,7 @@ tp_obj tpy_len(TP) {
 tp_obj tpy_range(TP) {
     int a,b,c,i;
     tp_obj r = tp_list_t(tp);
-    switch (tp->params.list.val->len) {
+    switch (tp->params->list.val->len) {
         case 1: a = 0; b = TP_NUM(); c = 1; break;
         case 2:
         case 3: a = TP_NUM(); b = TP_NUM(); c = TP_DEFAULT(tp_number(1)).number.val; break;
@@ -179,7 +179,7 @@ tp_obj tpy_object_new(TP) {
     tp_obj self = tp_object(tp);
     self.dict.val->meta = klass;
     TP_META_BEGIN(self, __init__);
-        tp_call(tp, __init__, tp->params);
+        tp_call(tp, __init__, *tp->params);
     TP_META_END;
     return self;
 }

--- a/tinypy/tpy_builtins.c
+++ b/tinypy/tpy_builtins.c
@@ -300,7 +300,7 @@ tp_obj tpy_eval(TP) {
 }
 
 tp_obj tpy_globals(TP) {
-    return tp->frames[tp->cur].frame.info->globals;
+    return tp_get_cur_frame(tp)->globals;
 }
 
 


### PR DESCRIPTION
As a preparation for adding a dict to the calling convention.

This PR makes tpd_frame a tp_obj, and adds frames to the garbage collector. Therefore we no longer need to push every member to the regs array. The offset of regs is eliminated.

Add stack allocator to tp_vm, and we obtain registers from the stack during IREG. IREG is always written to the preamble of code objects by the encoder, so this is fine.

- [x] We should be able to add frame->kwargs as the way to pass kwargs to Python functions.

- [] Still need to organize tp->params, the calling convention of C-API functions. I think the current approach have difficulty handling nested tpy calls. It does handle needling through C and Python due to tracking the frames. If we don't find a good way to fix this, then perhaps the least resistant approach is to augment tp_params from a TP_LIST to a new type, with TP_LIST + TP_DICT. Alternatively, change the calling convention of tpy_xxx to tpy_xxx(TP, tp_obj args, tp_obj kwargs), just like Python.

 