### PR TITLE
Fix number parsing.

### DIFF
--- a/tinypy/printf/mini-printf.h
+++ b/tinypy/printf/mini-printf.h
@@ -67,7 +67,4 @@ int mini_pprintf(int (*puts)(char*s, unsigned int len, void* buf), void* buf, co
 }
 #endif
 
-#define vsnprintf mini_vsnprintf
-#define snprintf mini_snprintf
-
 #endif

--- a/tinypy/tp_repr.c
+++ b/tinypy/tp_repr.c
@@ -90,10 +90,10 @@ void tp_str_(TP, tp_obj self, tpd_list * visited, StringBuilder * sb, int mode) 
         tp_num v = self.number.val;
         if ((fabs(v-(long)v)) < 0.000001) {
             snprintf(buf, 120, "%ld", (long)v);
-            string_builder_write(sb, buf, -1);
         } else {
-            snprintf(buf, 120, "%f", v);
+            snprintf(buf, 120, "%lf", (double)v);
         }
+        string_builder_write(sb, buf, -1);
     } else if(type == TP_DICT) {
         if(self.type.magic == TP_DICT_CLASS) {
             string_builder_write(sb, "C", -1);


### PR DESCRIPTION
Parsing of  negative integers were broke by #31 

This PR parses integer with strtoul as a fallback when there is no
negative sign.

Also fixes the formatting of floats. mini-printf (for the object extension) doesn't support floats,
so we gonna use stdlib's printf.

We probably want to support the 'u' suffix; not so sure -- cpython
doesn't not appear to support the syntax.