### PR TITLE
String enhancements

### DIFF
--- a/tests/test_str.py
+++ b/tests/test_str.py
@@ -75,6 +75,9 @@ class StringUnitTests(UnitTest):
         assert ord("\r") == 13
         assert ord("\t") == 9
         assert ord("\0") == 0
+        assert len("\xff") == 1
+        assert ord("\xff") == 255
+        assert ord("\x0f") == 15
 
 if __name__ == '__main__':
     tests = StringUnitTests()

--- a/tests/test_str.py
+++ b/tests/test_str.py
@@ -69,6 +69,13 @@ class StringUnitTests(UnitTest):
         assert j == '\0AB\0'
         assert len(j) == 4
 
+    def test_escape(self):
+        assert ord("\\") == 92
+        assert ord("\n") == 10
+        assert ord("\r") == 13
+        assert ord("\t") == 9
+        assert ord("\0") == 0
+
 if __name__ == '__main__':
     tests = StringUnitTests()
     tests.run()

--- a/tinypy/compiler/asm.py
+++ b/tinypy/compiler/asm.py
@@ -41,19 +41,16 @@ def assemble(asmc):
         a = int(a)
         b = int(b)
         c = int(c)
-        bc.append(chr(ops[i]))
-        bc.append(chr(a))
-        bc.append(chr(b))
-        bc.append(chr(c))
+        bc.extend(bytes([ops[i], a, b, c]))
         if i == "LINE":
             n = a * 4
             d = dequote(d)
             text = d
-            text += chr(0) * (n - len(d))
+            text += b'\0' * (n - len(d))
             bc.append(text)
         if i == "STRING":
             d = dequote(d)
-            text = d + "\0"*(4-len(d)%4)
+            text = d + b"\0"*(4-len(d)%4)
             bc.append(text)
         elif i == "NUMBER":
             d = int(d)

--- a/tinypy/compiler/boot.py
+++ b/tinypy/compiler/boot.py
@@ -70,10 +70,3 @@ else:
 
     def merge(a, b):
         a.update(b)
-
-    # tpy strings are byte strings.
-    def bytes(s):
-        return s
-
-    def bytearray(t):
-        return join([chr(i) for i in t])

--- a/tinypy/compiler/boot.py
+++ b/tinypy/compiler/boot.py
@@ -2,6 +2,7 @@ import sys
 
 if not "tinypy" in sys.version:
     import struct
+    _bytes = bytes
 
     ARGV = sys.argv
 
@@ -10,7 +11,7 @@ if not "tinypy" in sys.version:
         out = b''
         for el in v:
             # At this point all elements in v must be bytes.
-            if not isinstance(el, bytes):
+            if not isinstance(el, _bytes):
                 raise
                 el = el.encode()
             out += el
@@ -23,7 +24,7 @@ if not "tinypy" in sys.version:
             for k in b: setattr(a,k,b[k])
 
     def number(v):
-        if not isinstance(v, bytes):
+        if not isinstance(v, _bytes):
             raise
         if b'.' in v:
             return float(v)
@@ -56,6 +57,10 @@ if not "tinypy" in sys.version:
         r = f.read().decode()
         f.close()
         return r
+
+    if sys.version_info.major == 2:
+        def bytes(v):
+            return _bytes(bytearray(v))
 
     def save(fname,v):
         f = open(fname,'wb')

--- a/tinypy/compiler/disasm.py
+++ b/tinypy/compiler/disasm.py
@@ -54,11 +54,7 @@ def disassemble(bc):
             line = trim(line)
             ip += (int(n / 4) + 1) * 4
         elif i == opcodes.NUMBER:
-            f = unpack(chr(b), text(c,ip,bc))
-            line += " " + str(f)
-            ip += c
-        elif i == opcodes.INTEGER:
-            f = unpack(chr(b), text(c,ip,bc))
+            f = unpack('=' + chr(b), text(c,ip,bc))
             line += " " + str(f)
             ip += c
         asmc.append(line)

--- a/tinypy/compiler/disasm.py
+++ b/tinypy/compiler/disasm.py
@@ -15,7 +15,7 @@ def pad(s, n):
     return s + p
 
 def text(x, ip, bc):
-    return bytes(bytearray(bc[ip:ip+x]))
+    return bytes(bc[ip:ip+x])
 
 def trim(x):
     txt = []
@@ -24,7 +24,7 @@ def trim(x):
             txt.append(c)
     return "".join(txt)
 
-def disassemble(bc):    
+def disassemble(bc):
     bc = [x for x in bc]
     asmc = []
     ip = 0

--- a/tinypy/compiler/encode.py
+++ b/tinypy/compiler/encode.py
@@ -155,7 +155,7 @@ def map_tags():
             out[n] = item[1]
         elif item[0] == 'code':
             i,a,b,c = item[1:]
-            out[n] = bytes(bytearray((i,a,b,c)))
+            out[n] = bytes([i,a,b,c])
         else:
             raise str(('huh?',item))
         if len(out[n]) != 4:

--- a/tinypy/compiler/encode.py
+++ b/tinypy/compiler/encode.py
@@ -153,9 +153,11 @@ def map_tags():
         item = out[n]
         if item[0] == 'data':
             out[n] = item[1]
+            assert len(out[n]) == 4
         elif item[0] == 'code':
             i,a,b,c = item[1:]
             out[n] = bytes([i,a,b,c])
+            assert len(out[n]) == 4, len(out[n])
         else:
             raise str(('huh?',item))
         if len(out[n]) != 4:

--- a/tinypy/compiler/parse.py
+++ b/tinypy/compiler/parse.py
@@ -145,8 +145,8 @@ def get_led(t,left):
     return r
 def dot_led(t,left):
     r = expression(t.bp)
-    r.type = 'string'
-    t.items = [left,r]
+    r.type = 'name'
+    t.items = [left,r.as_string()]
     return t
 
 def itself(t):
@@ -273,7 +273,7 @@ def from_nud(t):
         else:
             break
 
-    expr = Token(t.pos, 'string', s)
+    expr = Token(t.pos, 'name', s)
     items.append(expr)
 
     advance('import')
@@ -293,7 +293,7 @@ def import_nud(t):
         else:
             break
 
-    expr = Token(t.pos, 'string', s)
+    expr = Token(t.pos, 'name', s)
     items.append(expr)
     if check(P.token, 'as'):
         advance('as')

--- a/tinypy/compiler/tokenize.py
+++ b/tinypy/compiler/tokenize.py
@@ -1,3 +1,5 @@
+from tinypy.compiler.boot import *
+
 class Token:
     def __init__(self,pos=(0,0),type='symbol',val=None,items=None):
         self.pos,self.type,self.val,self.items=pos,type,val,items

--- a/tinypy/compiler/tokenize.py
+++ b/tinypy/compiler/tokenize.py
@@ -10,6 +10,12 @@ class Token:
     def __repr__(self):
         return self._format()
 
+    def as_string(self):
+        if self.type == 'string':
+            raise
+            return self
+        return Token(self.pos, 'string', self.val.encode(), self.items)
+
     def update(self, other):
         for k in other:
             self[k] = other[k]
@@ -151,7 +157,7 @@ def do_name(s,i,l):
     return i
 
 def do_string(s,i,l):
-    v,q,i = '',s[i],i+1
+    v,q,i = b'',s[i],i+1
     if (l-i) >= 5 and s[i] == q and s[i+1] == q: # """
         i += 2
         while i<l-2:
@@ -161,7 +167,7 @@ def do_string(s,i,l):
                 T.add('string',v)
                 break
             else:
-                v,i = v+c,i+1
+                v,i = v+c.encode(),i+1
                 if c == '\n': T.y,T.yi = T.y+1,i
     else:
         while i<l:
@@ -175,13 +181,13 @@ def do_string(s,i,l):
                 elif c == "\\": c = "\\"
                 else:
                     u_error('tokenize',s,T.f)
-                v,i = v+c,i+1
+                v,i = v+c.encode(),i+1
             elif c == q:
                 i += 1
                 T.add('string',v)
                 break
             else:
-                v,i = v+c,i+1
+                v,i = v+c.encode(),i+1
     return i
 
 def do_comment(s,i,l):

--- a/tinypy/compiler/tokenize.py
+++ b/tinypy/compiler/tokenize.py
@@ -169,9 +169,12 @@ def do_string(s,i,l):
             if c == "\\":
                 i = i+1; c = s[i]
                 if c == "n": c = '\n'
-                if c == "r": c = chr(13)
-                if c == "t": c = "\t"
-                if c == "0": c = "\0"
+                elif c == "r": c = chr(13)
+                elif c == "t": c = "\t"
+                elif c == "0": c = "\0"
+                elif c == "\\": c = "\\"
+                else:
+                    u_error('tokenize',s,T.f)
                 v,i = v+c,i+1
             elif c == q:
                 i += 1

--- a/tinypy/compiler/tokenize.py
+++ b/tinypy/compiler/tokenize.py
@@ -174,14 +174,17 @@ def do_string(s,i,l):
             c = s[i]
             if c == "\\":
                 i = i+1; c = s[i]
-                if c == "n": c = '\n'
-                elif c == "r": c = chr(13)
-                elif c == "t": c = "\t"
-                elif c == "0": c = "\0"
-                elif c == "\\": c = "\\"
+                if c == "n": c = b'\n'
+                elif c == "r": c = b'\r'
+                elif c == "t": c = b'\t'
+                elif c == "0": c = b'\0'
+                elif c == "x" and i + 3 < l:
+                    c = bytes([int(s[i+1:i+3], 16)])
+                    i = i + 2
+                elif c == "\\": c = b'\\'
                 else:
                     u_error('tokenize',s,T.f)
-                v,i = v+c.encode(),i+1
+                v,i = v + c,i+1
             elif c == q:
                 i += 1
                 T.add('string',v)

--- a/tinypy/tpy_builtins.c
+++ b/tinypy/tpy_builtins.c
@@ -376,6 +376,23 @@ tp_obj tpy_dict_update(TP) {
     return tp_None;
 }
 
+tp_obj tpy_bytes(TP) {
+    tp_obj v = TP_PARAMS_OBJ();
+    if(v.type.typeid == TP_STRING) {
+        return v;
+    }
+    if(v.type.typeid != TP_LIST) {
+        tp_raise_printf(tp_None, "(tpy_bytes): Only take a list or a string");
+    }
+    tp_obj r = tp_string_t(tp, TPD_LIST(v)->len);
+    int i;
+    char * p = tp_string_getptr(r);
+    for(i = 0; i < TPD_LIST(v)->len; i ++) {
+        p[i] = TPN_AS_INT(TPD_LIST(v)->items[i]);
+    }
+    return r;
+}
+
 void tp_module_builtins_init(TP) {
     tp_obj builtins = tp_object(tp);
     tp_set(tp, builtins, tp_string_atom(tp, "MODULES"), tp->modules);
@@ -394,6 +411,7 @@ void tp_module_builtins_init(TP) {
     {"__import__",tpy_import},
     {"len",tpy_len},
     {"str", tpy_str},
+    {"bytes", tpy_bytes},
     {"float",tpy_float}, 
     {"istype",tpy_istype},
     {"isinstance",tpy_isinstance}, 


### PR DESCRIPTION
Internally represent string as bytes in the compiler. This allows the CPython backed compiler to properly represent
treat ttnypy strings which are always bytes.

add `\x` escape code.

add bytes() function to create bytes from a list of numbers. This is compabile with CPython, unlike 'chr', which is only compatible with Python 2. 